### PR TITLE
#183 - Fixing the front end for the tag page

### DIFF
--- a/App/PHP_HTML/tag.php
+++ b/App/PHP_HTML/tag.php
@@ -27,6 +27,7 @@ $qt = $_GET['tag'];
 <!DOCTYPE html>
 <html>
 <head>
+<div class="container">
     <title>Tags</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -50,4 +51,5 @@ $qt = $_GET['tag'];
     ?>
 
 </table>
+</div>
 </body>


### PR DESCRIPTION
Added the container div tag to indicate to bootstrap that the page needs to have formatting

What it looks like after the fix : 
![image](https://user-images.githubusercontent.com/13425936/38226618-95fa8ae2-36c8-11e8-90db-e5173d2157aa.png)
